### PR TITLE
Dynamically generate session page header

### DIFF
--- a/src/app/(sessions)/layout.tsx
+++ b/src/app/(sessions)/layout.tsx
@@ -1,12 +1,12 @@
 import { ReactNode } from 'react'
 import EndAppSessionButton from '#/components/buttons/EndAppSessionButton'
+import SessionPageHeader from '#/components/layout/SessionPageHeader'
 
 export default function SessionLayout({ children }: { children: ReactNode }) {
   return (
     <div className='relative w-full h-screen flex flex-col justify-center items-center'>
       <div className='absolute top-0 left-0 right-0 px-10 pt-6 flex justify-between items-center'>
-        {/* TODO: Dynamically generate page title */}
-        <h1 className='text-lg'>Flashcards</h1>
+        <SessionPageHeader />
         <EndAppSessionButton />
       </div>
       {children}

--- a/src/components/layout/SessionPageHeader.tsx
+++ b/src/components/layout/SessionPageHeader.tsx
@@ -1,0 +1,18 @@
+'use client'
+
+import { useAppSessionStore } from '#/store/app-session'
+import { useMemo } from 'react'
+
+export default function SessionPageHeader() {
+  const { sessionType } = useAppSessionStore((state) => state)
+
+  const pageHeader = useMemo(
+    () =>
+      sessionType
+        ? `${sessionType[0].toUpperCase()}${sessionType.slice(1)}`
+        : null,
+    [sessionType]
+  )
+
+  return <h1 className='text-lg'>{pageHeader ?? ''}</h1>
+}


### PR DESCRIPTION
Closes #48 
Closes #49 

This PR adds `metadata` property to app session store, so we can access additional values across the app